### PR TITLE
Fix rendering in Firefox

### DIFF
--- a/src/simulation/yarnSimulation.js
+++ b/src/simulation/yarnSimulation.js
@@ -186,7 +186,7 @@ export function simulate(pattern, yarnSequence, palette, scale) {
 
     Object.entries(layer).forEach(([colorIndex, paths]) => {
       context.strokeStyle = yarnPalette[colorIndex];
-      context.stroke(new Path2D(paths.join()));
+      context.stroke(new Path2D(paths.join(" ")));
     });
   }
 


### PR DESCRIPTION
Rendering paths individually worked, so tried some other things, and it turns out that separating our path specs with spaces when joining them makes Firefox happy. Not sure if this is Chrome being more lenient or Firefox not properly parsing, but either way, it does the job