### PR TITLE
Alternative rendering strategy

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -113,8 +113,11 @@ SIM PANE
 #mid,
 #front {
   position: absolute;
-  top: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
   left: 0;
+  top: 0;
 }
 
 /**********************************


### PR DESCRIPTION
Playing around with how knitscape renders the simulation. 

As it is currently implemented on `main`,
knitscape reruns `simulate()` anytime the simulation needs to be displayed (including when zooming).
`simulate()`, in turn, generates all the data again and again, even if nothing changed, and draws the full pattern (even if only a portion is visible, say, when we're really zoomed in). The upside is that panning is free and very snappy, since it's a pure CSS transform and the full pattern has been rendered.
But zooming is very laggy.

Here, I restrict the canvas layers to the visible portion of the simulation pane, and handle panning on the rendering side. I also cache layer data and merely redraw when panning and zooming, but don't recompute yarn path data. This means zooming very close to the pattern actually renders faster than zoomed out now, because the browser has fewer paths to draw.

So:
- Zooming is much faster than on `main`.
- Panning is a bit slower, because we re-render whereas `main` does nothing.
- It's possible to zoom and pan after relax and still see the relaxed pattern, whereas on `main` the data is erased as soon as we pan around.
- Relaxation also seems to be marginally faster.

Zoom center is a bit off, and flipped view is not panning correctly, so I still need to fix that.

There are probably further optimizations to explore, in order of complexity:
- Render the full simulation to svg, which should make everything fast.
  The relaxation could possibly even update the svg nodes directly.
- Do a hybrid approach where we only update the visible portion when zooming (to be fast), and then debounce the rendering of the full pattern once we stop moving, so that pan is free (like in `main`).
- Render repeated structures in offscreen canvases (say common stitches or so). But relaxation removes most repetition, unsure how beneficial it would be.
- Full GPU rendering. Will be very annoying to setup, but performance won't be an issue anymore.

